### PR TITLE
Change files names and reads names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,11 @@ core.*
 *.lai
 *.la
 *.a
+
+# Kdevelop files
+*.kdev4
+
+# Binaries
+indelstat_sam_bam
+pirs
+src/pirs/pirs

--- a/src/pirs/Read.h
+++ b/src/pirs/Read.h
@@ -18,33 +18,34 @@ class ReadPair;
  */
 class Indel {
 public:
-	int ref_idx;
-	int len;
-	Indel(int _ref_idx, int _len) : ref_idx(_ref_idx), len(_len) { }
+    int ref_idx;
+    int len;
+    Indel(int _ref_idx, int _len) : ref_idx(_ref_idx), len(_len) { }
 };
 
-/* 
+/*
  * Structure to represent a paired-end read.
  *
  * @pair is a reference to the containing ReadPair.
  */
 class Read {
 public:
-	vector<char>   seq;
-	vector<char>   raw_read;
-	vector<char>   ref_read;
-	vector<char>   quality_vals;
-	vector<Indel>  indels;
-	vector<int>    error_pos;
-	ReadPair      &pair;
-	int            mask_end_len;
+    vector<char>   seq;
+    vector<char>   raw_read;
+    vector<char>   ref_read;
+    vector<char>   quality_vals;
+    vector<Indel>  indels;
+    vector<int>    error_pos;
+    ReadPair      &pair;
+    int            mask_end_len;
+    string         indiv_name;
 
-	Read(ReadPair &_pair)
-		: pair(_pair), mask_end_len(0)
-	{ }
+    Read(ReadPair &_pair)
+        : pair(_pair), mask_end_len(0)
+    { }
 
-	inline int num_in_pair() const;
-	inline char orientation() const;
+    inline int num_in_pair() const;
+    inline char orientation() const;
 };
 
 /*
@@ -52,35 +53,40 @@ public:
  */
 class ReadPair {
 public:
-	Read         read_1;
-	Read         read_2;
-	const char  *ref_seq_id;
-	const char  *ref_filename;
-	int          insert_len;
-	size_t       ref_seq_pos;
-	uint64_t     pair_number;
-	int          insert_len_mean;
-	int          quality_shift;
-	bool         reverse_order;
-	bool         cyclicized;
+    Read         read_1;
+    Read         read_2;
+    const char  *ref_seq_id;
+    const char  *ref_filename;
+    int          insert_len;
+    size_t       ref_seq_pos;
+    uint64_t     pair_number;
+    int          insert_len_mean;
+    int          quality_shift;
+    bool         reverse_order;
+    bool         cyclicized;
 
-	ReadPair()
-		: read_1(*this), read_2(*this)
-	{ }
+    ReadPair()
+        : read_1(*this), read_2(*this)
+    { }
+
+    void set_indiv_name(string my_indiv_name) {
+        read_1.indiv_name = my_indiv_name;
+        read_2.indiv_name = my_indiv_name;
+    }
 };
 
 inline int Read::num_in_pair() const
 {
-	if (this == &pair.read_1)
-		return (pair.reverse_order) ? 2 : 1;
-	else
-		return (pair.reverse_order) ? 1 : 2;
+    if (this == &pair.read_1)
+        return (pair.reverse_order) ? 2 : 1;
+    else
+        return (pair.reverse_order) ? 1 : 2;
 }
 
 inline char Read::orientation() const
 {
-	return (pair.reverse_order ^ pair.cyclicized ^
-				(num_in_pair() == 1)) ? '+' : '-';
+    return (pair.reverse_order ^ pair.cyclicized ^
+            (num_in_pair() == 1)) ? '+' : '-';
 }
 
 
@@ -96,44 +102,44 @@ inline char Read::orientation() const
 #include <Lock.h>
 class ReadPairSet {
 private:
-	unsigned nrefs;
-	Lock nrefs_lock;
+    unsigned nrefs;
+    Lock nrefs_lock;
 public:
-	ReadPair *pairs;
-	ReadPairSet() {
-		pairs = new ReadPair[READS_PER_SET];
-	}
-	~ReadPairSet() { 
-		delete[] pairs;
-	}
+    ReadPair *pairs;
+    ReadPairSet() {
+        pairs = new ReadPair[READS_PER_SET];
+    }
+    ~ReadPairSet() {
+        delete[] pairs;
+    }
 
-	// Set the reference count of the ReadPairSet
-	void set_refs(unsigned n) {
-		nrefs = n;
-	}
+    // Set the reference count of the ReadPairSet
+    void set_refs(unsigned n) {
+        nrefs = n;
+    }
 
-	// Decrement the reference count of the ReadPairSet, returning true if
-	// it's now 0.
-	bool put_ref() {
-		nrefs_lock.lock();
-		unsigned n = --nrefs;
-		nrefs_lock.unlock();
-		return n == 0;
-	}
+    // Decrement the reference count of the ReadPairSet, returning true if
+    // it's now 0.
+    bool put_ref() {
+        nrefs_lock.lock();
+        unsigned n = --nrefs;
+        nrefs_lock.unlock();
+        return n == 0;
+    }
 };
 
 class ReadSet {
 public:
-	Read **reads;
-	ReadPairSet *pair_set;
-	bool is_last;
+    Read **reads;
+    ReadPairSet *pair_set;
+    bool is_last;
 
-	ReadSet() {
-		reads = new Read*[READS_PER_SET];
-	}
-	~ReadSet() {
-		delete[] reads;
-	}
+    ReadSet() {
+        reads = new Read*[READS_PER_SET];
+    }
+    ~ReadSet() {
+        delete[] reads;
+    }
 };
 #endif // ENABLE_THREADS
 

--- a/src/pirs/SimulationParameters.h
+++ b/src/pirs/SimulationParameters.h
@@ -10,54 +10,55 @@
 using std::string;
 
 enum SubstitutionErrorAlgorithm {
-	ALGO_DIST,
-	ALGO_QTRANS,
+    ALGO_DIST,
+    ALGO_QTRANS,
 };
 
 class SimulationParameters {
 public:
-	int read_len;
-	double coverage;
-	double insert_len_mean;
-	double insert_len_sd;
-	bool jumping;
-	bool diploid;
-	const char *base_calling_profile_filename;
-	const char *gc_bias_profile_filename;
-	const char *indel_profile_filename;
-	double error_rate;
-	enum SubstitutionErrorAlgorithm subst_error_algo;
-	casava::demultiplex::QualityMaskMode quality_mask_mode;
-	int quality_shift;
-	bool simulate_quality_values;
-	bool simulate_substitution_errors;
-	bool simulate_indels;
-	bool simulate_gc_bias;
-	bool write_log_files;
-	bool user_specified_random_seed;
-	uint64_t random_seed;
-	int num_simulator_threads;
-	string output_prefix;
-	const char **input_refs;
-	unsigned num_input_refs;
+    int read_len;
+    double coverage;
+    double insert_len_mean;
+    double insert_len_sd;
+    bool jumping;
+    bool diploid;
+    const char *base_calling_profile_filename;
+    const char *gc_bias_profile_filename;
+    const char *indel_profile_filename;
+    double error_rate;
+    enum SubstitutionErrorAlgorithm subst_error_algo;
+    casava::demultiplex::QualityMaskMode quality_mask_mode;
+    int quality_shift;
+    bool simulate_quality_values;
+    bool simulate_substitution_errors;
+    bool simulate_indels;
+    bool simulate_gc_bias;
+    bool write_log_files;
+    bool user_specified_random_seed;
+    uint64_t random_seed;
+    int num_simulator_threads;
+    string output_directory;
+    const char **input_refs;
+    unsigned num_input_refs;
+    string indiv_name;
 
-	SimulationParameters(int argc, char **argv);
+    SimulationParameters(int argc, char **argv);
 };
 
 class SimulationFiles {
 public:
-	InputStream  *in_files;
-	OutputStream  out_file_1;
-	OutputStream  out_file_2;
-	OutputStream  insert_distr_log_file;
-	OutputStream  info_log_file;
-	OutputStream  error_distr_log_file;
+    InputStream  *in_files;
+    OutputStream  out_file_1;
+    OutputStream  out_file_2;
+    OutputStream  insert_distr_log_file;
+    OutputStream  info_log_file;
+    OutputStream  error_distr_log_file;
 
-	SimulationFiles(const SimulationParameters &params);
+    SimulationFiles(const SimulationParameters &params);
 
-	~SimulationFiles() {
-		delete[] in_files;
-	}
+    ~SimulationFiles() {
+        delete[] in_files;
+    }
 };
 
 class GCBiasProfile;


### PR DESCRIPTION
We usually use fastq files names as name of samples. So user must specify it, without any suffix. Also we add this name as a read name prefix, so read names are uniq, also between several samples.